### PR TITLE
Add basic features section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TokenLaunch</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f9fafb; color: #333; }
+        header { background-color: #2c3e50; color: #fff; padding: 2rem 1rem; text-align: center; }
+        section { padding: 2rem 1rem; }
+        h2 { color: #2c3e50; }
+        .tweets { background-color: #ecf0f1; }
+        .features { background-color: #ffffff; }
+        .feature-grid { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }
+        .feature { background-color: #ecf0f1; padding: 1rem; border-radius: 8px; max-width: 250px; }
+        .steps { list-style-type: decimal; margin-left: 1.5rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>TokenLaunch</h1>
+        <p>Kickstart your crypto project with ease.</p>
+    </header>
+
+    <section class="tweets">
+        <h2>What People Are Saying</h2>
+        <p>Embed tweets here showing community excitement.</p>
+    </section>
+
+    <section class="features">
+        <h2>How to Launch Your Token</h2>
+        <ol class="steps">
+            <li>Connect your wallet.</li>
+            <li>Fill in your token details.</li>
+            <li>Set up your crowdsale parameters.</li>
+            <li>Deploy and share with your community.</li>
+        </ol>
+
+        <h2>Features</h2>
+        <div class="feature-grid">
+            <div class="feature">
+                <h3>Easy Deployment</h3>
+                <p>Launch on popular networks with one click.</p>
+            </div>
+            <div class="feature">
+                <h3>Community Tools</h3>
+                <p>Built-in token holder dashboards and analytics.</p>
+            </div>
+            <div class="feature">
+                <h3>Secure Contracts</h3>
+                <p>Audited smart contracts keep funds safe.</p>
+            </div>
+        </div>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple website HTML with tweets area
- create how-to and features sections styled inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684063e4cf1c8321bdc52872294a346b