### PR TITLE
Add HowItWorks and features sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import { Suspense, useState } from 'react';
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 import { TweetFeed } from '@/components/tweet/TweetFeed';
 import { TokenLaunchModal } from '@/components/tweet/TokenLaunchModal';
+import { Features } from '@/components/Features';
+import { HowItWorks } from '@/components/HowItWorks';
 import { EnrichedTweet } from '@/types/twitter'; // Changed Tweet to EnrichedTweet
 
 export default function Home() {
@@ -44,6 +46,10 @@ export default function Home() {
           </div>
         </div>
       </main>
+
+      {/* How it works and features sections */}
+      <HowItWorks />
+      <Features />
 
       <TokenLaunchModal
         isOpen={isModalOpen}

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+interface Step {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+function StepCard({ icon, title, description }: Step) {
+  return (
+    <div className="text-center bg-gray-900/70 border border-gray-700 rounded-xl p-8">
+      <div className="w-14 h-14 mx-auto mb-4 bg-gradient-to-br from-purple-600 to-pink-600 rounded-full flex items-center justify-center">
+        {icon}
+      </div>
+      <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+      <p className="text-gray-400 text-sm">{description}</p>
+    </div>
+  );
+}
+
+export function HowItWorks() {
+  const steps: Step[] = [
+    {
+      icon: (
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+        </svg>
+      ),
+      title: 'Connect Wallet',
+      description: 'Link your Solana wallet to access launch features.'
+    },
+    {
+      icon: (
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      ),
+      title: 'Pick a Tweet',
+      description: 'Choose a viral tweet from the feed that inspires you.'
+    },
+    {
+      icon: (
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M12 5l7 7-7 7" />
+        </svg>
+      ),
+      title: 'Launch on Raydium',
+      description: 'Customize your token details and deploy instantly.'
+    }
+  ];
+
+  return (
+    <section id="how-it-works" className="py-16 bg-black">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-bold text-center text-white mb-12">How It Works</h2>
+        <div className="grid md:grid-cols-3 gap-8">
+          {steps.map((step, i) => (
+            <StepCard key={i} {...step} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default HowItWorks;


### PR DESCRIPTION
## Summary
- create `HowItWorks` section with dark themed step cards
- insert `HowItWorks` and existing `Features` components on the home page

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68406631efbc832183e76ada4d46a3de