### PR TITLE
Add HowItWorks and features sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import { Suspense, useState } from 'react';
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 import { TweetFeed } from '@/components/tweet/TweetFeed';
 import { TokenLaunchModal } from '@/components/tweet/TokenLaunchModal';
+import { Features } from '@/components/Features';
+import { HowItWorks } from '@/components/HowItWorks';
 import { EnrichedTweet } from '@/types/twitter'; // Changed Tweet to EnrichedTweet
 
 export default function Home() {
@@ -27,7 +29,7 @@ export default function Home() {
       </header>
 
       <main className="container mx-auto px-4 py-8">
-        <div className="max-w-3xl mx-auto glass p-8 rounded-2xl relative overflow-hidden">
+        <div className="max-w-5xl mx-auto glass p-8 rounded-2xl relative overflow-hidden">
           <div className="crypto-circuit"> {/* This class was removed in globals.css, consider if it's still needed or if its styles should be merged/re-applied */}
             <div className="text-center mb-12">
               <h2 className="text-4xl font-bold mb-4 text-white"> {/* Changed to text-white */}
@@ -44,6 +46,10 @@ export default function Home() {
           </div>
         </div>
       </main>
+
+      {/* How it works and features sections */}
+      <HowItWorks />
+      <Features />
 
       <TokenLaunchModal
         isOpen={isModalOpen}

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -9,12 +9,12 @@ interface FeatureProps {
 
 function FeatureCard({ icon, title, description, gradient }: FeatureProps) {
   return (
-    <div className="group relative bg-white rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 border border-gray-100">
+    <div className="group relative bg-gray-900/70 border border-gray-700 rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
       <div className={`w-16 h-16 ${gradient} rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300`}>
         {icon}
       </div>
-      <h3 className="text-xl font-bold text-gray-900 mb-4">{title}</h3>
-      <p className="text-gray-600 leading-relaxed">{description}</p>
+      <h3 className="text-xl font-bold text-white mb-4">{title}</h3>
+      <p className="text-gray-300 leading-relaxed">{description}</p>
     </div>
   );
 }
@@ -84,19 +84,19 @@ export function Features() {
   ];
 
   return (
-    <section id="features" className="bg-gray-50 py-20 lg:py-28">
+    <section id="features" className="bg-black py-20 lg:py-28">
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           {/* Section header */}
           <div className="text-center mb-16">
-            <h2 className="text-4xl lg:text-5xl font-bold text-gray-900 mb-6">
+            <h2 className="text-4xl lg:text-5xl font-bold text-white mb-6">
               Everything You Need to
               <span className="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
                 {" "}Launch Successfully
               </span>
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
-              From token creation to DEX listing, we provide all the tools you need 
+            <p className="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+              From token creation to DEX listing, we provide all the tools you need
               to launch your project on Solana with confidence.
             </p>
           </div>
@@ -123,7 +123,7 @@ export function Features() {
               </p>
               <a
                 href="#launch"
-                className="inline-block bg-white text-purple-600 font-semibold px-8 py-4 rounded-xl hover:bg-gray-100 transition-colors duration-300"
+                className="inline-block bg-gray-900 text-white font-semibold px-8 py-4 rounded-xl hover:bg-gray-800 transition-colors duration-300"
               >
                 Get Started Now →
               </a>

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+interface Step {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+function StepCard({ icon, title, description }: Step) {
+  return (
+    <div className="text-center bg-gray-900/70 border border-gray-700 rounded-xl p-8">
+      <div className="w-14 h-14 mx-auto mb-4 bg-gradient-to-br from-purple-600 to-pink-600 rounded-full flex items-center justify-center">
+        {icon}
+      </div>
+      <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+      <p className="text-gray-400 text-sm">{description}</p>
+    </div>
+  );
+}
+
+export function HowItWorks() {
+  const steps: Step[] = [
+    {
+      icon: (
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+        </svg>
+      ),
+      title: 'Connect Wallet',
+      description: 'Link your Solana wallet to access launch features.'
+    },
+    {
+      icon: (
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      ),
+      title: 'Pick a Tweet',
+      description: 'Choose a viral tweet from the feed that inspires you.'
+    },
+    {
+      icon: (
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M12 5l7 7-7 7" />
+        </svg>
+      ),
+      title: 'Launch on Raydium',
+      description: 'Customize your token details and deploy instantly.'
+    }
+  ];
+
+  return (
+    <section id="how-it-works" className="py-16 bg-black">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-bold text-center text-white mb-12">How It Works</h2>
+        <div className="grid md:grid-cols-3 gap-8">
+          {steps.map((step, i) => (
+            <StepCard key={i} {...step} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default HowItWorks;

--- a/src/components/tweet/TokenLaunchModal.tsx
+++ b/src/components/tweet/TokenLaunchModal.tsx
@@ -142,8 +142,8 @@ export function TokenLaunchModal({ isOpen, onClose, tweet, onLaunch }: TokenLaun
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex min-h-full items-center justify-center p-4 text-center">
         <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
-        
-        <div className="relative w-full max-w-2xl transform rounded-2xl bg-gray-900 border border-gray-800/50 p-6 text-left shadow-xl transition-all">
+
+        <div className="relative w-full max-w-2xl transform rounded-2xl bg-gray-900/80 backdrop-blur-lg border border-gray-700 p-8 text-left shadow-2xl transition-all">
           {/* Modal Header */}
           <div className="mb-6">
             <h3 className="text-2xl font-bold text-white mb-2">Launch Token</h3>

--- a/src/components/tweet/TweetFeed.tsx
+++ b/src/components/tweet/TweetFeed.tsx
@@ -56,7 +56,26 @@ export function TweetFeed({ onTweetSelect, onTweetClick }: TweetFeedProps) {
           token_potential: { name_suggestion: 'Mock Coin', symbol_suggestion: 'MCK' },
           launch_status: 'not_launched'
         },
-        // Add more mock tweets as needed
+        {
+          id: "2",
+          text: "Another spicy take on memecoins going to the moon 🚀",
+          author: mockAuthor,
+          created_at: new Date(Date.now() - 1000000).toISOString(),
+          public_metrics: { ...mockMetrics, like_count: 75, retweet_count: 20 },
+          media: mockMedia,
+          token_potential: { name_suggestion: 'Spice Coin', symbol_suggestion: 'SPICE' },
+          launch_status: 'not_launched'
+        },
+        {
+          id: "3",
+          text: "Who else is farming airdrops this season? #airdrops",
+          author: mockAuthor,
+          created_at: new Date(Date.now() - 2000000).toISOString(),
+          public_metrics: { ...mockMetrics, like_count: 55, retweet_count: 15 },
+          media: mockMedia,
+          token_potential: { name_suggestion: 'Airdrop Coin', symbol_suggestion: 'DROP' },
+          launch_status: 'not_launched'
+        },
       ]);
       setLoading(false);
       setRefreshing(false);


### PR DESCRIPTION
## Summary
- create `HowItWorks` section with dark themed step cards
- insert `HowItWorks` and existing `Features` components on the home page
- dark-mode adjustments for features and launch modal
- widen tweet feed and add more mock tweets

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68406631efbc832183e76ada4d46a3de