### PR TITLE
Add Pump.fun token feed with mock fallback

### DIFF
--- a/src/app/api/pumpfun/route.ts
+++ b/src/app/api/pumpfun/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { pumpFunApi } from '@/services/pumpFunApi';
+
+export const revalidate = 30; // cache for 30 seconds
+
+export async function GET() {
+  const tokens = await pumpFunApi.getRecentTokens(20);
+  return NextResponse.json({ tokens });
+}

--- a/src/hooks/usePumpTokens.ts
+++ b/src/hooks/usePumpTokens.ts
@@ -12,7 +12,7 @@ export interface PumpToken {
   timestamp: string;
 }
 
-const API_URL = 'https://pumpportal.fun/api/v1/tokens/recent?limit=20';
+const API_URL = '/api/pumpfun';
 
 export function usePumpTokens(): [PumpToken[], boolean] {
   const [tokens, setTokens] = useState<PumpToken[]>([]);
@@ -23,7 +23,7 @@ export function usePumpTokens(): [PumpToken[], boolean] {
 
     const fetchTokens = async () => {
       try {
-        const res = await fetch(API_URL, { signal: controller.signal });
+        const res = await fetch(`${API_URL}?limit=20`, { signal: controller.signal });
         const data = await res.json();
         const list: PumpToken[] = data.tokens || data;
         setTokens((prev) => {
@@ -34,6 +34,15 @@ export function usePumpTokens(): [PumpToken[], boolean] {
       } catch (err) {
         if (controller.signal.aborted) return;
         console.error('Failed to fetch pump tokens', err);
+        try {
+          const res = await fetch('/api/pumpfun');
+          if (res.ok) {
+            const data = await res.json();
+            setTokens(data.tokens);
+          }
+        } catch (e) {
+          console.error('Fallback pumpfun request failed', e);
+        }
       } finally {
         setIsLoading(false);
       }

--- a/src/services/mockPumpTokens.ts
+++ b/src/services/mockPumpTokens.ts
@@ -1,0 +1,33 @@
+export interface PumpFunToken {
+  address: string;
+  metadata: {
+    name?: string;
+    symbol?: string;
+    description?: string;
+    image?: string;
+  };
+  timestamp: string;
+}
+
+export const mockPumpTokens: PumpFunToken[] = [
+  {
+    address: 'Token111111111111111111111111111111111',
+    metadata: {
+      name: 'Mock Fun',
+      symbol: 'MOCK',
+      description: 'Example token from pump.fun',
+      image: '/next.svg'
+    },
+    timestamp: new Date().toISOString()
+  },
+  {
+    address: 'Token222222222222222222222222222222222',
+    metadata: {
+      name: 'Sample Coin',
+      symbol: 'SAMP',
+      description: 'Sample token',
+      image: '/next.svg'
+    },
+    timestamp: new Date(Date.now() - 1000 * 60 * 60).toISOString()
+  }
+];

--- a/src/services/pumpFunApi.ts
+++ b/src/services/pumpFunApi.ts
@@ -1,0 +1,22 @@
+import { PumpFunToken, mockPumpTokens } from './mockPumpTokens';
+
+export class PumpFunApiService {
+  private baseUrl = process.env.NEXT_PUBLIC_PUMPFUN_API_URL || 'https://pump.fun/api/markets/recent?offset=0';
+
+  async getRecentTokens(limit = 20): Promise<PumpFunToken[]> {
+    try {
+      const url = `${this.baseUrl}&limit=${limit}`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      return data.tokens || data;
+    } catch (err) {
+      console.error('Pump.fun API failed, using mock data', err);
+      return mockPumpTokens;
+    }
+  }
+}
+
+export const pumpFunApi = new PumpFunApiService();


### PR DESCRIPTION
## Summary
- create pump.fun API endpoint `/api/pumpfun`
- add PumpFunApi service with mock fallback
- provide mock token data
- adjust `usePumpTokens` hook to use local pump.fun proxy

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684071283f5c8321ae5eb5943d65eab5