### PR TITLE
Add Bitquery Pump.fun API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,7 @@ NEXT_PUBLIC_TWITTER_BEARER_TOKEN=your_twitter_bearer_token_here
 # OpenAI API Configuration (for AI image generation)
 NEXT_PUBLIC_OPENAI_API_KEY=your_openai_api_key_here
 
+# Bitquery API key for Pump.fun data
+NEXT_PUBLIC_BITQUERY_KEY=your_bitquery_key_here
+
 # Other environment variables...

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The application expects these variables to be defined:
 
 - `NEXT_PUBLIC_TWITTER_BEARER_TOKEN` – Twitter API bearer token
 - `NEXT_PUBLIC_OPENAI_API_KEY` – OpenAI API key for image generation
+- `NEXT_PUBLIC_BITQUERY_KEY` – Bitquery API key for Pump.fun data
 
 🔧 Features & Components
 1. Homepage Feed

--- a/src/app/api/pumpfun/bitquery/route.ts
+++ b/src/app/api/pumpfun/bitquery/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { getRecentPumpFunTokens } from '@/services/bitqueryPumpFun';
+
+export const revalidate = 30;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = parseInt(searchParams.get('limit') ?? '10', 10);
+  const tokens = await getRecentPumpFunTokens(limit);
+  return NextResponse.json({ tokens });
+}

--- a/src/lib/bitqueryClient.ts
+++ b/src/lib/bitqueryClient.ts
@@ -1,5 +1,5 @@
 export async function bitqueryClient<T>(query: string, variables?: Record<string, any>, signal?: AbortSignal): Promise<T> {
-  const key = (import.meta as any).env?.VITE_BITQUERY_KEY || process.env.NEXT_PUBLIC_BITQUERY_KEY;
+  const key = process.env.NEXT_PUBLIC_BITQUERY_KEY || '';
   const res = await fetch('https://graphql.bitquery.io/', {
     method: 'POST',
     headers: {

--- a/src/services/__tests__/bitqueryPumpFun.test.ts
+++ b/src/services/__tests__/bitqueryPumpFun.test.ts
@@ -1,0 +1,53 @@
+import { getRecentPumpFunTokens } from '../bitqueryPumpFun';
+import { bitqueryClient } from '@/lib/bitqueryClient';
+
+jest.mock('@/lib/bitqueryClient');
+const mockedClient = bitqueryClient as jest.MockedFunction<typeof bitqueryClient>;
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('getRecentPumpFunTokens', () => {
+  it('maps API response', async () => {
+    mockedClient.mockResolvedValue({
+      data: {
+        Solana: {
+          TokenSupplyUpdates: [
+            {
+              Block: { Time: '2024-01-01T00:00:00Z' },
+              Transaction: { Signer: 'signer' },
+              TokenSupplyUpdate: {
+                Amount: 1,
+                PostBalance: 2,
+                Currency: {
+                  Name: 'Token',
+                  Symbol: 'TKN',
+                  MintAddress: 'mint',
+                  ProgramAddress: 'program'
+                }
+              }
+            }
+          ]
+        }
+      }
+    } as any);
+
+    const tokens = await getRecentPumpFunTokens(1);
+
+    expect(tokens).toEqual([
+      {
+        blockTime: '2024-01-01T00:00:00Z',
+        signer: 'signer',
+        amount: 1,
+        postBalance: 2,
+        currency: {
+          name: 'Token',
+          symbol: 'TKN',
+          mintAddress: 'mint',
+          programAddress: 'program'
+        }
+      }
+    ]);
+  });
+});

--- a/src/services/bitqueryPumpFun.ts
+++ b/src/services/bitqueryPumpFun.ts
@@ -1,0 +1,66 @@
+import { bitqueryClient } from '@/lib/bitqueryClient';
+
+export interface BitqueryPumpToken {
+  blockTime: string;
+  signer: string;
+  amount: number;
+  currency: {
+    name: string;
+    symbol: string;
+    mintAddress: string;
+    programAddress: string;
+  };
+  postBalance: number;
+}
+
+interface ResponseData {
+  data: {
+    Solana: {
+      TokenSupplyUpdates: Array<{
+        Block: { Time: string };
+        Transaction: { Signer: string };
+        TokenSupplyUpdate: {
+          Amount: number;
+          PostBalance: number;
+          Currency: {
+            Name: string;
+            Symbol: string;
+            MintAddress: string;
+            ProgramAddress: string;
+          };
+        };
+      }>;
+    };
+  };
+}
+
+const QUERY = `query RecentPumpFunTokens($limit: Int!) {
+  Solana {
+    TokenSupplyUpdates(limit: $limit, where: {Instruction: {Program: {Address: {is: \"6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P\"}, Method: {is: \"create\"}}}}) {
+      Block { Time }
+      Transaction { Signer }
+      TokenSupplyUpdate {
+        Amount
+        PostBalance
+        Currency { Name Symbol MintAddress ProgramAddress }
+      }
+    }
+  }
+}`;
+
+export async function getRecentPumpFunTokens(limit = 10, signal?: AbortSignal): Promise<BitqueryPumpToken[]> {
+  const res = await bitqueryClient<ResponseData>(QUERY, { limit }, signal);
+  const updates = res.data.Solana.TokenSupplyUpdates;
+  return updates.map(u => ({
+    blockTime: u.Block.Time,
+    signer: u.Transaction.Signer,
+    amount: u.TokenSupplyUpdate.Amount,
+    postBalance: u.TokenSupplyUpdate.PostBalance,
+    currency: {
+      name: u.TokenSupplyUpdate.Currency.Name,
+      symbol: u.TokenSupplyUpdate.Currency.Symbol,
+      mintAddress: u.TokenSupplyUpdate.Currency.MintAddress,
+      programAddress: u.TokenSupplyUpdate.Currency.ProgramAddress,
+    }
+  }));
+}


### PR DESCRIPTION
## Summary
- support Bitquery Pump.fun API via new service and API route
- document Bitquery env var
- add tests for the Bitquery Pump.fun service

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68407c082164832185c2d2ea9827869d