### PR TITLE
Add Pump.fun GraphQL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,8 @@ NEXT_PUBLIC_TWITTER_BEARER_TOKEN=your_twitter_bearer_token_here
 # OpenAI API Configuration (for AI image generation)
 NEXT_PUBLIC_OPENAI_API_KEY=your_openai_api_key_here
 
+# Pump.fun API (GraphQL)
+NEXT_PUBLIC_PUMPFUN_GQL_URL=https://api.pump.fun/graphql
+NEXT_PUBLIC_PUMPFUN_API_KEY=your_pumpfun_api_key_here
+
 # Other environment variables...

--- a/src/services/pumpFunApi.ts
+++ b/src/services/pumpFunApi.ts
@@ -1,11 +1,55 @@
 import { PumpFunToken, mockPumpTokens } from './mockPumpTokens';
 
 export class PumpFunApiService {
-  private baseUrl = process.env.NEXT_PUBLIC_PUMPFUN_API_URL || 'https://pump.fun/api/markets/recent?offset=0';
+  private restUrl = process.env.NEXT_PUBLIC_PUMPFUN_API_URL ||
+    'https://pump.fun/api/markets/recent?offset=0';
+  private gqlUrl = process.env.NEXT_PUBLIC_PUMPFUN_GQL_URL ||
+    'https://api.pump.fun/graphql';
+  private apiKey = process.env.NEXT_PUBLIC_PUMPFUN_API_KEY;
 
   async getRecentTokens(limit = 20): Promise<PumpFunToken[]> {
+    if (this.apiKey) {
+      try {
+        const query = `
+          query RecentMarkets($limit: Int!) {
+            recentMarkets(limit: $limit) {
+              address
+              metadata { name symbol description image }
+              createdAt
+            }
+          }
+        `;
+        const res = await fetch(this.gqlUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': this.apiKey,
+          },
+          body: JSON.stringify({ query, variables: { limit } }),
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const { data } = await res.json();
+        if (data?.recentMarkets) {
+          return data.recentMarkets.map((m: any) => ({
+            address: m.address,
+            metadata: {
+              name: m.metadata?.name,
+              symbol: m.metadata?.symbol,
+              description: m.metadata?.description,
+              image: m.metadata?.image,
+            },
+            timestamp: m.createdAt,
+          }));
+        }
+      } catch (err) {
+        console.error('Pump.fun GraphQL failed, falling back to REST', err);
+      }
+    }
+
     try {
-      const url = `${this.baseUrl}&limit=${limit}`;
+      const url = `${this.restUrl}&limit=${limit}`;
       const res = await fetch(url);
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
@@ -13,7 +57,7 @@ export class PumpFunApiService {
       const data = await res.json();
       return data.tokens || data;
     } catch (err) {
-      console.error('Pump.fun API failed, using mock data', err);
+      console.error('Pump.fun REST API failed, using mock data', err);
       return mockPumpTokens;
     }
   }


### PR DESCRIPTION
## Summary
- use Pump.fun GraphQL API when API key provided
- update env example with Pump.fun variables

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684079f7b0fc83218472c8713afe1d6b